### PR TITLE
Improved Dive and Fly Aesthetics

### DIFF
--- a/src/field_effect.c
+++ b/src/field_effect.c
@@ -2937,7 +2937,9 @@ static void SpriteCB_FieldMoveMonSlideOnscreen(struct Sprite *sprite)
         sprite->x = DISPLAY_WIDTH / 2;
         sprite->sOnscreenTimer = 30;
         sprite->callback = SpriteCB_FieldMoveMonWaitAfterCry;
-        if (sprite->data[6])
+        if (FindTaskIdByFunc(Task_UseDive) != TASK_NONE)
+            PlayCry_DuckNoRestore(sprite->sSpecies, 0, CRY_MODE_NORMAL);
+        else if (sprite->data[6])
             PlayCry_NormalNoDucking(sprite->sSpecies, 0, CRY_VOLUME_RS, CRY_PRIORITY_NORMAL);
         else
             PlayCry_Normal(sprite->sSpecies, 0);

--- a/src/field_effect.c
+++ b/src/field_effect.c
@@ -3233,6 +3233,9 @@ static void FlyOutFieldEffect_BirdSwoopDown(struct Task *task)
         task->tState++;
         PlaySE(SE_M_FLY);
         StartFlyBirdSwoopDown(task->tBirdSpriteId);
+        if (GetWarpDestinationMusic() != GetCurrentMapMusic()) {
+            TryFadeOutOldMapMusic();
+        }
     }
 }
 

--- a/src/field_screen_effect.c
+++ b/src/field_screen_effect.c
@@ -34,6 +34,7 @@
 #include "constants/rgb.h"
 #include "trainer_hill.h"
 #include "fldeff.h"
+#include "m4a.h"
 
 static void Task_ExitNonAnimDoor(u8);
 static void Task_ExitNonDoor(u8);
@@ -484,12 +485,17 @@ static bool32 WaitForWeatherFadeIn(void)
 void DoWarp(void)
 {
     ScriptContext2_Enable();
-    TryFadeOutOldMapMusic();
     WarpFadeOutScreen();
     PlayRainStoppingSoundEffect();
     PlaySE(SE_EXIT);
     gFieldCallback = FieldCB_DefaultWarpExit;
     CreateTask(Task_WarpAndLoadMap, 10);
+    if (GetWarpDestinationMusic() == GetCurrentMapMusic()) {
+        m4aMPlayVolumeControl(&gMPlayInfo_BGM, TRACKS_ALL, 256);
+    }
+    else {
+        FadeOutMapMusic(1);
+    }
 }
 
 void DoDiveWarp(void)

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1196,8 +1196,6 @@ void Overworld_PlaySpecialMapMusic(void)
     {
         if (gSaveBlock1Ptr->savedMusic)
             music = gSaveBlock1Ptr->savedMusic;
-        else if (GetCurrentMapType() == MAP_TYPE_UNDERWATER)
-            music = MUS_UNDERWATER;
         else if (TestPlayerAvatarFlags(PLAYER_AVATAR_FLAG_SURFING) && SurfMusicAllowed(TRUE))
             music = MUS_SURF;
     }

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1224,8 +1224,6 @@ static void TransitionMapMusic(void)
         u16 currentMusic = GetCurrentMapMusic();
         if (newMusic != MUS_ABNORMAL_WEATHER && newMusic != MUS_NONE)
         {
-            if (currentMusic == MUS_UNDERWATER || currentMusic == MUS_SURF)
-                return;
             if (TestPlayerAvatarFlags(PLAYER_AVATAR_FLAG_SURFING))
                 newMusic = MUS_SURF;
         }


### PR DESCRIPTION
Underwater areas can now use any background music (before, all areas were forced to use MUS_UNDERWATER regardless of their map header), and the audio fade-out that normally occurs when diving now only plays when the underwater and surface areas don't share themes (the fade-out itself has been improved as well - no more awkward volume spikes at the last frame!). Additionally, using Fly now fades out the BGM for a smoother musical experience.