### PR TITLE
Final Mon Music

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -608,6 +608,7 @@ struct BattleStruct
     u8 stickyWebUser;
     u8 appearedInBattle; // Bitfield to track which Pokemon appeared in battle. Used for Burmy's form change
     u8 skyDropTargets[MAX_BATTLERS_COUNT]; // For Sky Drop, to account for if multiple Pokemon use Sky Drop in a double battle.
+    u8 finalMonMusicPlaying;
 };
 
 #define F_DYNAMIC_TYPE_1 (1 << 6)
@@ -779,6 +780,10 @@ struct BattleSpriteData
     struct BattleAnimationInfo *animationData;
     struct BattleBarInfo *battleBars;
 };
+
+u8 GetRemainingOpponentMons();
+bool8 IsOpponentFinalMon();
+u16 GetFinalMonMusic();
 
 #include "sprite.h"
 

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -1854,6 +1854,8 @@ u8 CreatePartyStatusSummarySprites(u8 battlerId, struct HpAndStatus *partyInfo, 
     }
 
     PlaySE12WithPanning(SE_BALL_TRAY_ENTER, 0);
+    if (IsOpponentFinalMon() && GetFinalMonMusic() != 0 && gBattleStruct->finalMonMusicPlaying == 0)
+        FadeOutBGM(16);
     return taskId;
 }
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -5408,3 +5408,32 @@ bool32 IsWildMonSmart(void)
 {
     return (B_SMART_WILD_AI_FLAG != 0 && FlagGet(B_SMART_WILD_AI_FLAG));
 }
+
+u8 GetRemainingOpponentMons() {
+    u8 remaining = PARTY_SIZE;
+    u8 i;
+    for (i = 0; i < PARTY_SIZE; i++)
+    {
+        if (GetMonData(&gEnemyParty[i], MON_DATA_SPECIES2) == SPECIES_NONE
+            || GetMonData(&gEnemyParty[i], MON_DATA_SPECIES2) == SPECIES_EGG
+            || GetMonData(&gEnemyParty[i], MON_DATA_HP) == 0)
+        {
+            remaining--;
+        }
+    }
+    return remaining;
+}
+
+bool8 IsOpponentFinalMon() {
+    return ((!IsDoubleBattle() && GetRemainingOpponentMons() == 1)
+        || (IsDoubleBattle() && GetRemainingOpponentMons() <= 2));
+}
+
+u16 GetFinalMonMusic() {
+    switch (gTrainers[gTrainerBattleOpponent_A].trainerClass) {
+    case TRAINER_CLASS_LEADER:
+        return MUS_VS_FRONTIER_BRAIN;
+    default:
+        return 0;
+    }
+}

--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -377,6 +377,7 @@ static void CreateBattleStartTask(u8 transition, u16 song)
     u8 taskId = CreateTask(Task_BattleStart, 1);
 
     gTasks[taskId].tTransition = transition;
+    gBattleStruct->finalMonMusicPlaying = 0;
     PlayMapChosenOrBattleBGM(song);
 }
 

--- a/src/pokeball.c
+++ b/src/pokeball.c
@@ -548,6 +548,11 @@ u8 DoPokeballSendOutAnimation(s16 pan, u8 kindOfThrow)
     gDoingBattleAnim = TRUE;
     gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].ballAnimActive = 1;
 
+    if (kindOfThrow == POKEBALL_OPPONENT_SENDOUT && IsOpponentFinalMon() && GetFinalMonMusic() != 0 && gBattleStruct->finalMonMusicPlaying == 0) {
+        PlayBGM(GetFinalMonMusic());
+        gBattleStruct->finalMonMusicPlaying = 1;
+    }
+    
     taskId = CreateTask(Task_DoPokeballSendOutAnim, 5);
     gTasks[taskId].tPan = pan;
     gTasks[taskId].tThrowId = kindOfThrow;


### PR DESCRIPTION
This adds a Gen V-style music change when a Gym Leader is down to their final team member (or final two team members during Double Battles). This implementation uses MUS_VS_FRONTIER_BRAIN for demonstrational purposes, but the exact track(s) (as well as the trainers it plays for) can be changed to anything by editing `GetFinalMonMusic()`'s switch statement in battle_main.c.